### PR TITLE
fix: Change shebang at the begining of a shell script

### DIFF
--- a/bin/mdsanima-colors
+++ b/bin/mdsanima-colors
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.

--- a/bin/mdsanima-shell
+++ b/bin/mdsanima-shell
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.

--- a/bin/mdsanima-theme
+++ b/bin/mdsanima-theme
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.

--- a/bin/mdsanima-weather
+++ b/bin/mdsanima-weather
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.


### PR DESCRIPTION
Changed the shebang in the script from `#!/bin/bash` to a more portable `#!/usr/bin/env bash`. This modification aims to enhance the script's portability across different operating systems.

Using `#!/usr/bin/env bash` allows the script to dynamically locate the bash interpreter in the current environment, eliminating potential issues associated with variations in the location of the bash interpreter on different systems. Additionally, this adjustment facilitates collaboration with environments where program paths may differ.

The purpose of this change is to improve the script's portability and minimize the need for manual updates to the bash interpreter path in case of any future changes.