### PR TITLE
fix: Set horizontal blinking cursor style at VimLeave

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -17,9 +17,12 @@ set expandtab           " Override mode for TAB
 set nobackup            " Dont make backups
 set nowritebackup       " Dont save backups
 
-" Keyboard shortcuts setup
+" Keyboard shortcuts
 map <C-S> :w<CR>        " Save file     CTRL+S
-map <C-Q> :q<CR>        " Exit Vim      CTRL+S
+map <C-Q> :q<CR>        " Exit Vim      CTRL+Q
 
-" Shows hidden setup
+" Shows hidden
 set list listchars=tab:»\ ,extends:→,precedes:←,nbsp:·,trail:·,
+
+" Cursor style
+autocmd VimLeave * set guicursor=a:ver1-blinkon1


### PR DESCRIPTION
The cursor doesn't change back to original style after leaving Vim on WSL and Windows Terminal.

https://github.com/microsoft/terminal/issues/13420#issuecomment-1501102143

https://github.com/neovim/neovim/issues/4867#issuecomment-291249173