### PR TITLE
fix: Add branch cleanup alias to gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -14,6 +14,7 @@
 	dh = diff HEAD
 	lg = log -p
 	lp = log --pretty=oneline
+	prune-branches = git branch -l | grep -v 'main' | xargs -r git branch -D
 
 [include]
 	path = ~/.gitcredentials


### PR DESCRIPTION
Introduced a new git alias `prune-branches` to quickly remove all local branches except `main`. This streamlines the cleanup process, reducing clutter, and keeping the working environment tidy and focused on active branches.