### PR TITLE
style: Normalize indentation and update `.editorconfig`

### DIFF
--- a/.config/nvim/.mappings.vim
+++ b/.config/nvim/.mappings.vim
@@ -6,5 +6,5 @@
 
 
 " Mappings shortcuts
-map <C-S> :w<CR>			" CTRL+S to Save file
-map <C-Q> :q<CR>			" CTRL+Q to Quit file
+map <C-S> :w<CR>            " CTRL+S to Save file
+map <C-Q> :q<CR>            " CTRL+Q to Quit file

--- a/.config/nvim/.settings.vim
+++ b/.config/nvim/.settings.vim
@@ -6,34 +6,34 @@
 
 
 " Settings options
-set autoindent				" Indent from last line
-set autoread				" Read file on change
-set backup					" Make backups files
-set clipboard=unnamedplus	" Use system clipboard
-set encoding=utf-8			" Character encoding
-set expandtab				" Override mode for TAB
-set history=1000			" Lines to keep in history
-set ignorecase				" Case insensitive search
-set incsearch				" Incremental search
-set linebreak				" Wrap long lines
-set list					" Show special characters
-set listchars+=extends:→,	" Show right arrow
-set listchars+=nbsp:·,		" Show non-breakable space
-set listchars+=precedes:←,	" Show left arrow
-set listchars+=tab:»\ ,		" Show tabs character
-set listchars+=trail:·,		" Show trailing spaces
-set mouse=a					" Mouse support
-set number					" Show line numbering
-set relativenumber			" Relative number of lines
-set scrolloff=10			" Lines after before cursor
-set shiftwidth=4			" Offset spaces
-set showbreak=↪\ 			" Show break character
-set smartcase				" Smart case search
-set splitbelow				" Split below side
-set splitright				" Split right side
-set tabstop=4				" Ident spaces
-set undofile				" Persistent undo
-set writebackup				" Make backups files
+set autoindent              " Indent from last line
+set autoread                " Read file on change
+set backup                  " Make backups files
+set clipboard=unnamedplus   " Use system clipboard
+set encoding=utf-8          " Character encoding
+set expandtab               " Override mode for TAB
+set history=1000            " Lines to keep in history
+set ignorecase              " Case insensitive search
+set incsearch               " Incremental search
+set linebreak               " Wrap long lines
+set list                    " Show special characters
+set listchars+=extends:→,   " Show right arrow
+set listchars+=nbsp:·,      " Show non-breakable space
+set listchars+=precedes:←,  " Show left arrow
+set listchars+=tab:»\ ,     " Show tabs character
+set listchars+=trail:·,     " Show trailing spaces
+set mouse=a                 " Mouse support
+set number                  " Show line numbering
+set relativenumber          " Relative number of lines
+set scrolloff=10            " Lines after before cursor
+set shiftwidth=4            " Offset spaces
+set showbreak=↪\            " Show break character
+set smartcase               " Smart case search
+set splitbelow              " Split below side
+set splitright              " Split right side
+set tabstop=4               " Ident spaces
+set undofile                " Persistent undo
+set writebackup             " Make backups files
 
 " Directories
 set backupdir=$HOME/.cache/nvim/backup//

--- a/.editorconfig
+++ b/.editorconfig
@@ -85,7 +85,7 @@ max_line_length = 120
 
 [*.vim]
 indent_size = 4
-indent_style = tab
+indent_style = space
 
 [*.yml]
 indent_size = 2


### PR DESCRIPTION
Standardized whitespace in Vim config files for better consistency and readability. Replaced tabs with spaces in `.editorconfig` for `.vim` files to align with established coding standards.

Related: #42 #41

Changed: #35