### PR TITLE
refactor: Neovim config and keybinds structure

### DIFF
--- a/.config/nvim/.autocmds.vim
+++ b/.config/nvim/.autocmds.vim
@@ -1,9 +1,0 @@
-" Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
-" Licensed under the MIT license.
-
-" This file sets up the basic autocommands options for Neovim.
-" This config shuld be sourced in the `init.vim` file.
-
-
-" Terminal cursor style
-autocmd VimLeave * set guicursor=a:ver1-blinkon1

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -1,8 +1,8 @@
 " Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
 " Licensed under the MIT license.
 
-" This is a basic initial configuration Vim Script file for Neovim editor.
-" For more info see official repository: https://github.com/neovim/neovim/
+" This is a initial configuration script for Neovim.
+" Repository: https://github.com/neovim/neovim/
 
 
 " Base initial setup
@@ -10,6 +10,8 @@ colorscheme pablo
 syntax on
 
 " Load configurations sources
-source $HOME/.config/nvim/.settings.vim
-source $HOME/.config/nvim/.mappings.vim
-source $HOME/.config/nvim/.autocmds.vim
+source $HOME/.config/nvim/settings.vim
+source $HOME/.config/nvim/keymaps.vim
+
+" Back to default terminal cursor style
+autocmd VimLeave * set guicursor=a:ver1-blinkon1

--- a/.config/nvim/keymaps.vim
+++ b/.config/nvim/keymaps.vim
@@ -1,10 +1,10 @@
 " Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
 " Licensed under the MIT license.
 
-" This file sets up the basic mappings shortcuts for Neovim.
-" This config should be sourced in the `init.vim` file.
+" This file sets up the keymaps for Neovim.
+" Should be sourced in the `init.vim` file.
 
 
-" Mappings shortcuts
+" Keymaps
 map <C-S> :w<CR>            " CTRL+S to Save file
 map <C-Q> :q<CR>            " CTRL+Q to Quit file

--- a/.config/nvim/settings.vim
+++ b/.config/nvim/settings.vim
@@ -1,11 +1,11 @@
 " Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
 " Licensed under the MIT license.
 
-" This file sets up the basic settings options for Neovim.
-" This config shuld be sourced in the `init.vim` file.
+" This file sets up the settings for Neovim.
+" Shuld be sourced in the `init.vim` file.
 
 
-" Settings options
+" Settings
 set autoindent              " Indent from last line
 set autoread                " Read file on change
 set backup                  " Make backups files


### PR DESCRIPTION
Streamlined Neovim's init script by removing `.autocmds.vim`, which reduces clutter and centralizes terminal cursor preferences directly within `init.vim`. Segregated key mapping and settings into `keymaps.vim` and `settings.vim` respectively, promoting better organization and improved readability of the configuration. This change will simplify future customizations and maintenance of Neovim's configuration files.

Changed: #41