### PR TITLE
feat: Add ASCII art banner functionality and update error text styling

### DIFF
--- a/.local/bin/mdsanima-banners
+++ b/.local/bin/mdsanima-banners
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Licensed under the MIT license.
+
+# This is a ASCII art banners with colors for `mdsanima-shell` script.
+# The all baners is generated from command-line tool called `figlet` by
+# typing `figlet -f future "mdsanima-shell"` and here is a colorized version
+# with some font and colors variants thats may be useful for other purposes.
+
+
+# Import default colors definition and help function for printing text in colors
+source "$PWD/mdsanima-colors"
+source "$PWD/mdsanima-prints"
+
+# Pringing ASCII art lines
+function __mds_shell_banner() {
+    __mds_color_print -fg ROSE   "┏┳┓╺┳┓┏━┓┏━┓┏┓╻╻┏┳┓┏━┓   ┏━┓╻ ╻┏━╸╻  ╻  "
+    __mds_color_print -fg RED    "┃┃┃ ┃┃┗━┓┣━┫┃┗┫┃┃┃┃┣━┫╺━╸┗━┓┣━┫┣╸ ┃  ┃  "
+    __mds_color_print -fg ORANGE "╹ ╹╺┻┛┗━┛╹ ╹╹ ╹╹╹ ╹╹ ╹   ┗━┛╹ ╹┗━╸┗━╸┗━╸"
+}

--- a/.local/bin/mdsanima-prints
+++ b/.local/bin/mdsanima-prints
@@ -32,8 +32,8 @@ function __mds_color_print() {
     local bg_seq="\e[48;5;"
     local reset_code="\e[0m"
 
-    # Define black bold error text on red background
-    local _error_="${fg_seq}16;01m${bg_seq}196m ERROR ${reset_code}"
+    # Define white bold error text on red background
+    local _error_="${fg_seq}15;01m${bg_seq}196m ERROR ${reset_code}"
 
     # Define defaults red error text
     local color_error="${fg_seq}196m Color number must be between 0 and 255${reset_code}"


### PR DESCRIPTION
Introduced a new script for generating colorized ASCII art banners using `figlet`, enhancing the visual appeal of the `mdsanima-shell` script. It includes sourcing color definitions and print functions, and custom banner art with multiple color variants. Separately, improved error message visibility in the `mdsanima-prints` script by switching error text from black bold to white bold on a red background, ensuring better readability under various terminal color schemes.

Resolves readability concerns in terminal UI.