### PR TITLE
fix: Disable terminal GUI color support in nvim theme

### DIFF
--- a/.config/nvim/colors/mdsanima.vim
+++ b/.config/nvim/colors/mdsanima.vim
@@ -7,6 +7,7 @@
 
 " Basic
 hi clear
+set notermguicolors
 set background=dark
 let g:colors_name = "mdsanima"
 


### PR DESCRIPTION
Turned off terminal GUI colors in the `mdsanima` theme configuration to fix color display issues in environments that do not support GUI color schemes. This ensures consistent color presentation across various terminal setups.