### PR TITLE
fix: Typo and improve module path handling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,16 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
-# This is a installation script for `Oh My Zsh` terminal configuration. This
-# script also colorize print text in a fancy way.
+# This is a installation script for MDSANIMA DEV dotfiles on Linux terminal configuration.
 
+
+# Import necessary modules
+. "$PWD/modules/mdsanima-shell/private/banner.sh"
+. "$PWD/modules/mdsanima-shell/private/event.sh"
+. "$PWD/modules/mdsanima-shell/private/print.sh"
+. "$PWD/modules/mdsanima-shell/public/colors.sh"
 
 # List of packages to install
 APT_PACKAGES="python3-pip zsh powerline fonts-powerline zsh-theme-powerlevel9k"
@@ -14,38 +19,13 @@ APT_PACKAGES_OPTIONAL="curl git htop vim tmux mc neofetch cmatrix ffmpeg"
 # Get the current tag from the Git repository
 CURRENT_GIT_TAG=$(git describe --tags)
 
-# Import default colors definition and help function for printing text in colors
-source "$PWD/.local/bin/mdsanima-colors"
-source "$PWD/.local/bin/mdsanima-prints"
-
-
-# Event logs information
-function _print_event() {
-    local bg_color="$1"
-    local fg_color="$2"
-    local log_info="$3"
-    __mds_color_print -fg WHITE -bg $bg_color -nonewline " MDSANIMA DEV "
-    __mds_color_print -fg $fg_color " $log_info"
+dotfiles_installer() {
+    __mds_ascii_banner
+    __mds_event_log $BLUE "MDSANIMA DEV" "dotfiles $CURRENT_GIT_TAG"
+    __mds_color_print " "
+    __mds_color_print -fg $WHITE "This installer is only available for Linux system."
+    __mds_color_print " "
+    __mds_color_print -fg $GRAY "Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved. Licensed under the MIT license."
 }
 
-
-# Version and application name
-function show_version() {
-    __mds_color_print " "
-    _print_event GRAY SKY "dotfiles $CURRENT_GIT_TAG"
-    __mds_color_print " "
-}
-
-
-# Help instruction
-function show_help() {
-    __mds_color_print -fg WHITE "This installer is only available for Linux system."
-    __mds_color_print " "
-    __mds_color_print -fg RED "Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved. Licensed under the MIT license."
-    __mds_color_print " "
-}
-
-
-# Run these functions
-show_version
-show_help
+dotfiles_installer

--- a/modules/mdsanima-shell/mdsanima-shell.sh
+++ b/modules/mdsanima-shell/mdsanima-shell.sh
@@ -5,16 +5,18 @@
 # files in `mdsanima-shell` module. The module is the part of `mdsanima-dev` dotfiles project.
 
 
+# Get the current directory
+MODULE_DIR="$(dirname "$0")"
+
 # Import private modules
-source "$PWD/private/banner.sh"
-source "$PWD/private/event.sh"
-source "$PWD/private/print.sh"
-source "$PWD/private/prompt.sh"
-source "$PWD/private/weather.sh"
+. "$MODULE_DIR/private/banner.sh"
+. "$MODULE_DIR/private/event.sh"
+. "$MODULE_DIR/private/print.sh"
+. "$MODULE_DIR/private/prompt.sh"
+. "$MODULE_DIR/private/weather.sh"
 
 # Import public modules
-source "$PWD/public/colors.sh"
-
+. "$MODULE_DIR/public/colors.sh"
 
 # The alternative to `__mds_color_print` function, it works the same way
 cprint() {

--- a/modules/mdsanima-shell/private/event.sh
+++ b/modules/mdsanima-shell/private/event.sh
@@ -19,10 +19,10 @@
 # Arguments:
 #     <event_color>    The color number (integer) or name (string) for the bg color of the event and fg text, required
 #     <event_name>     The event name (string), required
-#     <evnet_text>     The text (string) to be printed in colors, required
+#     <event_text>     The text (string) to be printed in colors, required
 #
 # Usage:
-#     __mds_event_log <event_color> <event_name> <evnet_text>
+#     __mds_event_log <event_color> <event_name> <event_text>
 #     __mds_event_log $BLUE "DEV" "This is a dev event"
 #     __mds_event_dev "This is a dev event"
 #     __mds_event_info "This is a info event"
@@ -33,12 +33,12 @@
 
 
 __mds_event_log() {
-    local event_color=$1
-    local event_name=$2
-    local event_text=$3
+    local event_color="$1"
+    local event_name="$2"
+    local event_text="$3"
 
     __mds_color_print -fg $BLACK -bg $event_color -b -n " $event_name "
-    __mds_color_print -fg $evnet_color " $evnet_text"
+    __mds_color_print -fg $event_color " $event_text"
 }
 
 __mds_event_dev() {

--- a/modules/mdsanima-shell/private/print.sh
+++ b/modules/mdsanima-shell/private/print.sh
@@ -54,7 +54,7 @@ __mds_color_print() {
         case "$1" in
             -fg)
                 if [ "$2" -gt 255 ]; then
-                    echo -e "${_error_}${color_number_error}" >&2
+                    echo "${_error_}${color_number_error}" >&2
                     return 1
                 fi
                 fg_color="$2"
@@ -62,7 +62,7 @@ __mds_color_print() {
                 ;;
             -bg)
                 if [ "$2" -gt 255 ]; then
-                    echo -e "${_error_}${color_number_error}" >&2
+                    echo "${_error_}${color_number_error}" >&2
                     return 1
                 fi
                 bg_color="$2"
@@ -94,7 +94,7 @@ __mds_color_print() {
 
     # Error if no text
     if [ -z "$text" ]; then
-        echo -e "${_error_}${no_text_error}" >&2
+        echo "${_error_}${no_text_error}" >&2
         return 1
     fi
 
@@ -124,8 +124,8 @@ __mds_color_print() {
 
     # Printing text
     if [ "$no_newline" = true ]; then
-        echo -e -n "${fg_code}${bold_seq}${italic_seq}${bg_code}${text}${reset}"
+        echo -n "${fg_code}${bold_seq}${italic_seq}${bg_code}${text}${reset}"
     else
-        echo -e "${fg_code}${bold_seq}${italic_seq}${bg_code}${text}${reset}"
+        echo "${fg_code}${bold_seq}${italic_seq}${bg_code}${text}${reset}"
     fi
 }


### PR DESCRIPTION
The script now dynamically gets the current module directory for sourcing scripts, addressing issues with varying execution paths. This update improves the reliability and portability of the script across different environments. Additionally, a typo in a parameter name inside an event logging function has been corrected. The misuse of `echo -e` has been replaced with a plain `echo` command, following best practices to avoid unexpected behavior regarding escape sequences in different shells.

The module `mdsanima-shell` only work on script thats the shebang is `#!/bin/sh` on the first line on the script.

Related: #55