### PR TITLE
fix: Updated Git config for simplified push and rebase pull

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -2,6 +2,12 @@
 	editor = nvim
 	symlinks = true
 
+[push]
+	default = simple
+
+[pull]
+	rebase = true
+
 [alias]
 	st = status
 	ci = commit --verbose


### PR DESCRIPTION
Configured git to use the `simple` pushing strategy and to rebase instead of merge on pull, optimizing the workflow and reducing merge conflicts. This setting makes push defaults safer and pull updates cleaner by rebasing local changes on top of fetched commits.