### PR TITLE
chore: Update copyright year

### DIFF
--- a/.commitlintrc
+++ b/.commitlintrc
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This is a configuration file for Commitlint that makes sharing commit conventions easy.

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This is a configuration file that helps maintain consistent coding styles for

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # Automatically keep the dependencies and packages updated to the latest version.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This file is used to declaratively define the GitHub repository default labels.

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # Linting commit messages with commitlint GitHub Action workflow on PR.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # Syncing GitHub repository labels defined in the YAML configuration file.

--- a/.zprofile
+++ b/.zprofile
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This is a profile configuration file for Zsh shell.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/config/aliasrc
+++ b/config/aliasrc
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This is a custom aliases definitions file for Linux system.

--- a/config/nvim/autoload/mdsanima.vim
+++ b/config/nvim/autoload/mdsanima.vim
@@ -1,4 +1,4 @@
-" Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+" Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 " Licensed under the MIT license.
 
 " This file sets up the mdsanima functions for the Neovim.

--- a/config/nvim/colors/mdsanima.vim
+++ b/config/nvim/colors/mdsanima.vim
@@ -1,4 +1,4 @@
-" Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+" Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 " Licensed under the MIT license.
 
 " This is a color file for custom theme in Neovim.

--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -1,4 +1,4 @@
-" Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+" Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 " Licensed under the MIT license.
 
 " This is a initial configuration script for Neovim.

--- a/config/nvim/keymaps.vim
+++ b/config/nvim/keymaps.vim
@@ -1,4 +1,4 @@
-" Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+" Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 " Licensed under the MIT license.
 
 " This file sets up the keymaps for Neovim.

--- a/config/nvim/settings.vim
+++ b/config/nvim/settings.vim
@@ -1,4 +1,4 @@
-" Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+" Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 " Licensed under the MIT license.
 
 " This file sets up the settings for Neovim.

--- a/config/tmux/mdsanima.conf
+++ b/config/tmux/mdsanima.conf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This is a tmux custom session configuration settings for my home labs hosts

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This is a tmux base global configuration settings for my home lab hosts and

--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This is a custom configuration `.zshrc` file for Linux system. You can use

--- a/config/zsh/themes/mdsanima.zsh
+++ b/config/zsh/themes/mdsanima.zsh
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This is a configuration file for the `Oh My Zsh` terminal and Powerlevel10k

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This is a installation script for `Oh My Posh` a prompt theme engine.
@@ -74,7 +74,7 @@ function Write-ShowHelp {
     Write-ShowVersion
     Write-Host "  This installer is only available for Windows on PowerShell terminal." -ForegroundColor White
     Write-Host ""
-    Write-Host "  Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved. Licensed under the MIT license." -ForegroundColor Blue
+    Write-Host "  Copyright (c) 2024 MDSANIMA DEV. All rights reserved. Licensed under the MIT license." -ForegroundColor Blue
     Write-Host ""
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This is a installation script for MDSANIMA DEV dotfiles on Linux terminal configuration.
@@ -25,7 +25,7 @@ dotfiles_installer() {
     __mds_color_print " "
     __mds_color_print -fg $WHITE "This installer is only available for Linux system."
     __mds_color_print " "
-    __mds_color_print -fg $GRAY "Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved. Licensed under the MIT license."
+    __mds_color_print -fg $GRAY "Copyright (c) 2024 MDSANIMA DEV. All rights reserved. Licensed under the MIT license."
 }
 
 dotfiles_installer

--- a/lib/mdsanima-shell/libcolor.sh
+++ b/lib/mdsanima-shell/libcolor.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # Defining default color names with color code number thats is used in the

--- a/lib/mdsanima-shell/libprint.sh
+++ b/lib/mdsanima-shell/libprint.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This library is designed for printing the text in colors and other styles.

--- a/templates/.dockerignore
+++ b/templates/.dockerignore
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This directories and files are not copied into the container during the build process.

--- a/templates/.eslintignore
+++ b/templates/.eslintignore
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This is a configuration file for ignoring eslint files on this repository.

--- a/templates/.eslintrc
+++ b/templates/.eslintrc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+// Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 // Licensed under the MIT license.
 
 // The eslint configuration file with the header plugin and custom rules.
@@ -13,7 +13,7 @@
     "quotes": ["error", "double"],
     "semi": ["error", "never"],
     "header/header": ["error", "line", [
-      " Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.",
+      " Copyright (c) 2024 MDSANIMA DEV. All rights reserved.",
       " Licensed under the MIT license."
     ], 2]
   },

--- a/templates/.flake8
+++ b/templates/.flake8
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This is a configuration file for Python package style checking.

--- a/templates/.pylintrc
+++ b/templates/.pylintrc
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
 # This is a configuration file for code linting in Python package.


### PR DESCRIPTION
Adjusted the copyright year to 2024 designation for all relevant files within the project to reflect the new year, ensuring the intellectual property rights are up-to-date.

This change doesn't impact the functionality of the code but maintains legal accuracy.