### PR TITLE
refactor: Rename print functions to mprint

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@
 
 # Import necessary libraries
 source "$PWD/lib/mdsanima-shell/libcolor.sh"
-source "$PWD/lib/mdsanima-shell/libprint.sh"
+source "$PWD/lib/mdsanima-shell/libmprint.sh"
 
 # List of packages to install
 APT_PACKAGES="python3-pip zsh powerline fonts-powerline zsh-theme-powerlevel9k"
@@ -18,10 +18,10 @@ APT_PACKAGES_OPTIONAL="curl git htop vim tmux mc neofetch cmatrix ffmpeg"
 CURRENT_GIT_TAG=$(git describe --tags)
 
 function dotfiles_installer() {
-  print::color -fg ${WHITE} -bg ${BLUE} -b -n " MDSANIMA DEV "
-  print::color -fg ${BLUE} " dotfiles ${CURRENT_GIT_TAG}\n"
-  print::color -fg ${WHITE} "This installer is only available for GNU/Linux systems, like Debian or Ubuntu.\n"
-  print::color -fg ${GRAY} "Copyright (c) 2024 MDSANIMA DEV. All rights reserved. Licensed under the MIT license."
+  mprint::color -fg ${WHITE} -bg ${BLUE} -b -n " MDSANIMA DEV "
+  mprint::color -fg ${BLUE} " dotfiles ${CURRENT_GIT_TAG}\n"
+  mprint::color -fg ${WHITE} "This installer is only available for GNU/Linux systems, like Debian or Ubuntu.\n"
+  mprint::color -fg ${GRAY} "Copyright (c) 2024 MDSANIMA DEV. All rights reserved. Licensed under the MIT license."
 }
 
 dotfiles_installer

--- a/lib/README.md
+++ b/lib/README.md
@@ -20,11 +20,11 @@ List of available files and functions:
   - `event::info`
   - `event::success`
   - `event::warning`
-- `libprint.sh`: Functions for print text messages in colors.
-  - `print::color`
+- `libmprint.sh`: Functions for print text messages in colors.
+  - `mprint::color`
 - `libutil.sh`: Utility functions.
   - `util::one_line_progress`
-  - `util::check_package_is_installed`
+  - `util::check_package_installed`
 
 Each file above contains appropriate documentation for each available function and how to use it.
 
@@ -46,24 +46,24 @@ Example script file `test.sh` must be located on the root of this repository:
 # Importing libraries
 source "$PWD/lib/mdsanima-shell/libcolor.sh"
 source "$PWD/lib/mdsanima-shell/libevent.sh"
-source "$PWD/lib/mdsanima-shell/libprint.sh"
+source "$PWD/lib/mdsanima-shell/libmprint.sh"
 source "$PWD/lib/mdsanima-shell/libutil.sh"
 
-# Testing print functions
-print::color -fg ${WHITE} -bg ${BLUE} -bold -nonewline " MDSANIMA "
-print::color -fg 27 " Blue text next to other"
-print::color -fg ${BLACK} -bg ${RED} "Black text on red background"
-print::color -fg 15 -bg 9 -bold "Bold white text on red background"
-print::color "Normal text"
-print::color -fg 196 "Red text"
-print::color -fg 196 -b "Bold red text"
-print::color -fg 196 -i "Italic red text"
-print::color -fg ${BLUE} -b -italic "Bold italic blue text"
-print::color -n "This line is printed in "
-print::color -fg ${RED} -n "red "
-print::color -fg ${GREEN} -n "green "
-print::color -fg ${BLUE} -n "blue "
-print::color "colored text"
+# Testing mprint functions
+mprint::color -fg ${WHITE} -bg ${BLUE} -bold -nonewline " MDSANIMA "
+mprint::color -fg 27 " Blue text next to other"
+mprint::color -fg ${BLACK} -bg ${RED} "Black text on red background"
+mprint::color -fg 15 -bg 9 -bold "Bold white text on red background"
+mprint::color "Normal text"
+mprint::color -fg 196 "Red text"
+mprint::color -fg 196 -b "Bold red text"
+mprint::color -fg 196 -i "Italic red text"
+mprint::color -fg ${BLUE} -b -italic "Bold italic blue text"
+mprint::color -n "This line is printed in "
+mprint::color -fg ${RED} -n "red "
+mprint::color -fg ${GREEN} -n "green "
+mprint::color -fg ${BLUE} -n "blue "
+mprint::color "colored text"
 
 # Testing event functions
 event::dev
@@ -76,7 +76,7 @@ echo -e "${clean_line_seq}${done} Testing event functions was finished!"
 
 # Tesging util functions
 util::one_line_progress sudo apt update
-if util::check_package_is_installed git; then
+if util::check_package_installed git; then
   echo "Package git is installed!"
 else
   echo "Package git is not installed!"

--- a/lib/mdsanima-shell/libevent.sh
+++ b/lib/mdsanima-shell/libevent.sh
@@ -7,25 +7,25 @@
 
 
 function event::debug() {
-  print::color -fg ${BLACK} -bg ${GRAY} -b " DEBUG "
+  mprint::color -fg ${BLACK} -bg ${GRAY} -b " DEBUG "
 }
 
 function event::dev() {
-  print::color -fg ${BLACK} -bg ${BLUE} -b " DEV "
+  mprint::color -fg ${BLACK} -bg ${BLUE} -b " DEV "
 }
 
 function event::error() {
-  print::color -fg ${BLACK} -bg ${RED} -b " ERROR "
+  mprint::color -fg ${BLACK} -bg ${RED} -b " ERROR "
 }
 
 function event::info() {
-  print::color -fg ${BLACK} -bg ${SKY} -b " INFO "
+  mprint::color -fg ${BLACK} -bg ${SKY} -b " INFO "
 }
 
 function event::success() {
-  print::color -fg ${BLACK} -bg ${LIME} -b " SUCCESS "
+  mprint::color -fg ${BLACK} -bg ${LIME} -b " SUCCESS "
 }
 
 function event::warning() {
-  print::color -fg ${BLACK} -bg ${ORANGE} -b " WARNING "
+  mprint::color -fg ${BLACK} -bg ${ORANGE} -b " WARNING "
 }

--- a/lib/mdsanima-shell/libmprint.sh
+++ b/lib/mdsanima-shell/libmprint.sh
@@ -17,12 +17,12 @@
 #   <text>          The text to be printed in colors, required
 #
 # Usage:
-#   print::color -fg <color> -bg <color> -bold -italic -nonewline <text>
-#   print::color -fg 15 -bg 9 -bold "Bold white text on red background"
-#   print::color -fg 196 -b -italic "Bold italic red text"
-#   print::color -fg ${WHITE} -bg ${RED} "White text on red background"
+#   mprint::color -fg <color> -bg <color> -bold -italic -nonewline <text>
+#   mprint::color -fg 15 -bg 9 -bold "Bold white text on red background"
+#   mprint::color -fg 196 -b -italic "Bold italic red text"
+#   mprint::color -fg ${WHITE} -bg ${RED} "White text on red background"
 #-------------------------------------------------------------------------------
-function print::color() {
+function mprint::color() {
   local fg_color
   local bg_color
   local bold_text

--- a/lib/mdsanima-shell/libutil.sh
+++ b/lib/mdsanima-shell/libutil.sh
@@ -41,10 +41,10 @@ function util::one_line_progress() {
 #   1 if the package is not installed
 #
 # Usage:
-#   util::check_package_is_installed <package>
-#   util::check_package_is_installed git
+#   util::check_package_installed <package>
+#   util::check_package_installed git
 #-------------------------------------------------------------------------------
-function util::check_package_is_installed() {
+function util::check_package_installed() {
   local package="$1"
   local query=$(dpkg-query -W -f='${Status}' "${package}" 2>/dev/null)
 


### PR DESCRIPTION
The shell script library has been refactored to rename `print` functions to `mprint` to align with naming conventions.

Updated `install.sh`, `libevent.sh`, and all relevant documentation and examples to reflect this change.

Also, streamlined the `util::check_package_installed` function for consistent phrasing. This change may require updates to scripts relying on the old function names.

Renamed `libprint.sh` to `libmprint.sh` and updated all usages. Renamed function `util::check_package_is_installed` to `util::check_package_installed` for clarity.

Adjusted documentation and test scripts to use the new names and revised function.

This refactor improves semantic clarity and consistency in the codebase.

Related: #69