### PR TITLE
feat: Add library for convert functions

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -8,27 +8,29 @@ Currently, the libraries are only available within this project and cannot be in
 
 This library contains functions thats help to execute _Shell Scripts_ on **GNU/Linux** systems, like _Debian_ or _Ubuntu_.
 
-## Available Functions
+## Available functions
 
 List of available files and functions:
 
-- `libcolor.sh`: Defined color names with color code number.
-- `libevent.sh`: Functions for print event names in colors.
+- `libcolor.sh`: Color schemes.
+- `libconvert.sh`: Functions for converting.
+  - `conver::hex_to_rgb`
+- `libevent.sh`: Functions for event logs.
   - `event::debug`
   - `event::dev`
   - `event::error`
   - `event::info`
   - `event::success`
   - `event::warning`
-- `libmprint.sh`: Functions for print text messages in colors.
+- `libmprint.sh`: Functions for printing.
   - `mprint::color`
-- `libutil.sh`: Utility functions.
-  - `util::one_line_progress`
+- `libutil.sh`: Functions for utility.
   - `util::check_package_installed`
+  - `util::one_line_progress`
 
 Each file above contains appropriate documentation for each available function and how to use it.
 
-## Example Usages
+## Example usages
 
 If you want to use this library files you can simple sourced this file on your bash script like this example:
 

--- a/lib/mdsanima-shell/libconvert.sh
+++ b/lib/mdsanima-shell/libconvert.sh
@@ -1,0 +1,29 @@
+# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
+# Licensed under the MIT license.
+
+# This library is for converting functions.
+
+
+#-------------------------------------------------------------------------------
+# This function converting HEX color code to RGB values. The returned values are
+# separated by semicolon and will be used in another function.
+#
+# Arguments:
+#   <hex_color>  The hexadecimal color code string, required
+#
+# Usage:
+#   convert::hex_to_rgb <hex_color>
+#   convert::hex_to_rgb "#ff0000"
+#-------------------------------------------------------------------------------
+function convert::hex_to_rgb() {
+  local hex_color="$1"
+  local awk_cmd='{print strtonum("0x" $0)}'
+
+  # Converting
+  local r=$(echo "${hex_color:1:2}" | awk "${awk_cmd}")
+  local g=$(echo "${hex_color:3:2}" | awk "${awk_cmd}")
+  local b=$(echo "${hex_color:5:2}" | awk "${awk_cmd}")
+
+  # Return RGB
+  echo "$r;$g;$b"
+}

--- a/lib/mdsanima-shell/libutil.sh
+++ b/lib/mdsanima-shell/libutil.sh
@@ -9,28 +9,6 @@ declare clean_line_seq="\r\e[0K"
 
 
 #-------------------------------------------------------------------------------
-# This function provides a simple way to execute bash commands with one line in
-# the stdout progress by reading each line of the stdout and displaying it with
-# overwriting the previous line.
-#
-# Arguments:
-#   <command>  The command to be executed, required
-#
-# Usage:
-#   util::one_line_progress <command>
-#   util::one_line_progress sudo apt update
-#-------------------------------------------------------------------------------
-function util::one_line_progress() {
-  local command="$@"
-
-  # Execute the command and read each line of the stdout
-  ${command} 2>&1 | while IFS= read -r line; do
-    echo -n -e "${clean_line_seq}${line}"
-  done
-}
-
-
-#-------------------------------------------------------------------------------
 # This function provides a simple way to check if a package is installed.
 #
 # Arguments:
@@ -54,4 +32,26 @@ function util::check_package_installed() {
   else
     return 1
   fi
+}
+
+
+#-------------------------------------------------------------------------------
+# This function provides a simple way to execute bash commands with one line in
+# the stdout progress by reading each line of the stdout and displaying it with
+# overwriting the previous line.
+#
+# Arguments:
+#   <command>  The command to be executed, required
+#
+# Usage:
+#   util::one_line_progress <command>
+#   util::one_line_progress sudo apt update
+#-------------------------------------------------------------------------------
+function util::one_line_progress() {
+  local command="$@"
+
+  # Execute the command and read each line of the stdout
+  ${command} 2>&1 | while IFS= read -r line; do
+    echo -n -e "${clean_line_seq}${line}"
+  done
 }


### PR DESCRIPTION
Enhanced the shell libraries by introducing a new `libconvert.sh` library with a `convert::hex_to_rgb` function, enabling hexadecimal to RGB color conversions.

Updated documentation and example usages sections in the README for clarity and consistency. Restructured functions into more descriptive categories, with conversion and printing functions now clearly delineated.

Improved the utility module by repositioning the `util::one_line_progress` function for better readability in the codebase.