### PR TITLE
style: Simplify config files and update patterns

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,5 @@
-# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
-# Licensed under the MIT license.
+# Maintain consistent coding style
 
-# This is a configuration file that helps maintain consistent coding styles for
-# multiple developers working on the same project across various editors and IDEs.
-# Documentation: https://editorconfig.org/
-
-
-# EditorConfig setup
 root = true
 
 [*]
@@ -19,7 +12,7 @@ trim_trailing_whitespace = true
 max_line_length = 120
 quote_type = double
 
-[*.{commitlintrc,eslint*,js,jsx,json,md,mjs,ts,tsx}]
+[*.{commitlintrc,eslint*,js,jsx,json,md,mjs,ts,tsx,versionrc}]
 indent_size = 2
 
 [*.{html,yml,yaml}]

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
-# This is a configuration file for ignoring files on this repository.
-# Documentation: https://help.github.com/articles/ignoring-files/
-
-# The template for Python and Node is sourced from GitHub by creating a new repository and initializing it.
-
+# Defined base templates
 
 # .gitignore template: Python
 # Byte-compiled / optimized / DLL files

--- a/.versionrc
+++ b/.versionrc
@@ -1,6 +1,6 @@
 {
   "infile": "CHANGELOG.md",
-  "header": "# Changelog\n\nAll notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org/) for commit guidelines.\n\nDocumentation for the [mdsanima-dev](https://pypi.org/project/mdsanima-dev/) package is available on [docs.mdsanima.dev](https://docs.mdsanima.dev/) site, and in the [README](README.md) file. Be sure to check it.\n\n<!-- markdownlint-disable -->\n",
+  "header": "# Changelog\n\nAll notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org/) for commit guidelines.\n\n<!-- markdownlint-disable -->\n",
   "skip": { "bump": false, "changelog": false, "commit": true, "tag": true },
   "types": [
     { "type": "feat",      "section": "🐱‍👤 Features",                  "hidden": false },

--- a/.zprofile
+++ b/.zprofile
@@ -1,9 +1,2 @@
-# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
-# Licensed under the MIT license.
-
-# This is a profile configuration file for Zsh shell.
-
-
-# Base configuration
 export EDITOR="nvim"
 export ZDOTDIR="$HOME/.config/zsh"

--- a/config/aliasrc
+++ b/config/aliasrc
@@ -1,10 +1,3 @@
-# Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
-# Licensed under the MIT license.
-
-# This is a custom aliases definitions file for GNU/Linux systems.
-
-
-# Aliases for internal hosts
 alias rpi0="ssh mdsanima@192.168.1.27"
 alias rpi1="ssh mdsanima@192.168.1.32"
 alias rpi2="ssh mdsanima@192.168.1.34"
@@ -17,9 +10,7 @@ alias jet1="ssh mdsanima@192.168.1.24"
 alias jet2="ssh mdsanima@192.168.1.30"
 alias macb="ssh mdsanima@192.168.1.44"
 
-# Aliases for Kubernetes
 alias k="kubectl"
 
-# Aliases for Neovim
 alias vi="nvim"
 alias vim="nvim"

--- a/config/ssh/.gitkeep
+++ b/config/ssh/.gitkeep
@@ -1,2 +1,0 @@
-<!-- This file is meant for maintaining the folder structure and will be committed. -->
-<!-- You can delete it later once there is content found in this folder. -->

--- a/templates/.gitkeep
+++ b/templates/.gitkeep
@@ -1,2 +1,1 @@
-<!-- This file is meant for maintaining the folder structure and will be committed. -->
-<!-- You can delete it later once there is content found in this folder. -->
+<!-- Keep this directory -->


### PR DESCRIPTION
Streamlined the `.editorconfig` and `.gitignore` by removing verbose comments and simplified `.versionrc` header content. Additionally, extended the coding styles in `.editorconfig` to include the `.versionrc` file. Removed `.gitkeep` in `config/ssh` as it's now redundant while updating`templates/.gitkeep` to preserve the directory structure. Reduced clutter in custom alias definitions and removed unnecessary comments and licensing headers to achieve a cleaner, more focused configuration across various files.