### PR TITLE
style: Update changelog section names for clarity

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -3,16 +3,16 @@
   "header": "# Changelog\n\nAll notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org/) for commit guidelines.\n\n<!-- markdownlint-disable -->\n",
   "skip": { "bump": false, "changelog": false, "commit": true, "tag": true },
   "types": [
-    { "type": "feat",      "section": "🐱‍👤 Features",                  "hidden": false },
-    { "type": "fix",       "section": "🐛 Bug Fixes",                 "hidden": false },
-    { "type": "perf",      "section": "🚀 Performance Improvements",  "hidden": false },
-    { "type": "revert",    "section": "♻️ Reverts",                   "hidden": false },
-    { "type": "docs",      "section": "📚 Documentation",             "hidden": false },
-    { "type": "style",     "section": "🧢 Styles",                    "hidden": false },
-    { "type": "chore",     "section": "🎮 Miscellaneous",             "hidden": false },
-    { "type": "refactor",  "section": "💻 Code Refactoring",          "hidden": false },
-    { "type": "test",      "section": "🤿 Tests",                     "hidden": false },
-    { "type": "build",     "section": "📦 Dependencies",              "hidden": false },
-    { "type": "ci",        "section": "🚧 Continuous Integration",    "hidden": false }
+    { "type": "feat",      "section": "🤿 Enhancements",   "hidden": false },
+    { "type": "perf",      "section": "🚀 Performance",    "hidden": false },
+    { "type": "fix",       "section": "🚧 Fixes",          "hidden": false },
+    { "type": "refactor",  "section": "💻 Refactors",      "hidden": false },
+    { "type": "docs",      "section": "📝 Documentation",  "hidden": false },
+    { "type": "revert",    "section": "♻️ Revert",         "hidden": false },
+    { "type": "build",     "section": "📦 Build",          "hidden": false },
+    { "type": "style",     "section": "🧢 Style",          "hidden": false },
+    { "type": "chore",     "section": "🎪 Chore",          "hidden": false },
+    { "type": "test",      "section": "🎮 Tests",          "hidden": false },
+    { "type": "ci",        "section": "🤖 CI",             "hidden": false }
   ]
 }


### PR DESCRIPTION
Updated types name for generating `CHANGELOG.md` from commit messages using `standard-version` command.

Standardized section headings in the changelog configuration to improve readability and consistency. Enhanced sections now more accurately reflect content types, such as grouping feature-related changes under "Enhancements" and simplifying the Continuous Integration section to "CI". Removed redundancy and ensured that the emoticons matched the intent of the sections.

This revamp facilitates quicker navigation and understanding of the projects history in the changelog.

## Types of section names

This is how the current type section names appear in the changelog file:

|       Type | Section          |
| ---------: | ---------------- |
|     `feat` | 🤿 Enhancements  |
|     `perf` | 🚀 Performance   |
|      `fix` | 🚧 Fixes         |
| `refactor` | 💻 Refactors     |
|     `docs` | 📝 Documentation |
|   `revert` | ♻️ Revert        |
|    `build` | 📦 Build         |
|    `style` | 🧢 Style         |
|    `chore` | 🎪 Chore         |
|     `test` | 🎮 Tests         |
|       `ci` | 🤖 CI            |

Additional items that should be added if necessary during a new release but were not mentioned in the file include:

- ⚠️ BREAKING CHANGES
- ❤️ Contributors