### PR TITLE
fix: Enable rerere option in gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,13 +1,3 @@
-[core]
-	editor = nvim
-	symlinks = true
-
-[push]
-	default = simple
-
-[pull]
-	rebase = true
-
 [alias]
 	st = status
 	ci = commit --verbose
@@ -18,16 +8,22 @@
 	bd = branch -D
 	df = diff
 	dh = diff HEAD
-	lg = log -p
-	lp = log --pretty=oneline
+	lo = log -p
+	ll = log --pretty=oneline
 	prune-branches = git branch -l | grep -v 'main' | xargs -r git branch -D
-
-[include]
-	path = ~/.gitcredentials
-
-[init]
-	defaultbranch = main
-
 [commit]
 	gpgsign = true
 	verbose = true
+[core]
+	editor = nvim
+	symlinks = true
+[include]
+	path = ~/.gitcredentials
+[init]
+	defaultbranch = main
+[pull]
+	rebase = true
+[push]
+	default = simple
+[rerere]
+	enabled = true


### PR DESCRIPTION
Introduced `rerere` functionality to remember resolved conflicts, potentially reducing future merge overhead. An advanced source control feature called _REuse REcorded REsolution_ enables automated conflict resolution between commits in a git repository. Its abbreviated name is **RERERE**.

Streamlined the `.gitconfig` organization by regrouping related settings for clarity and maintenance ease.

Additionally, changed alias log commands adjustments e.g., 'lg' to 'lo' and 'lp' to 'll' improve consistency in naming conventions.