### PR TITLE
refactor: Rename `libmprint.sh` to `libprint.sh` in lib

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@
 
 # Import necessary libraries
 source "$PWD/lib/mdsanima-shell/libcolor.sh"
-source "$PWD/lib/mdsanima-shell/libmprint.sh"
+source "$PWD/lib/mdsanima-shell/libprint.sh"
 
 # List of packages to install
 APT_PACKAGES="python3-pip zsh powerline fonts-powerline zsh-theme-powerlevel9k"
@@ -18,10 +18,10 @@ APT_PACKAGES_OPTIONAL="curl git htop vim tmux mc neofetch cmatrix ffmpeg"
 CURRENT_GIT_TAG=$(git describe --tags)
 
 function dotfiles_installer() {
-  mprint::color -fg ${WHITE} -bg ${BLUE} -b -n " MDSANIMA DEV "
-  mprint::color -fg ${BLUE} " dotfiles ${CURRENT_GIT_TAG}\n"
-  mprint::color -fg ${WHITE} "This installer is only available for GNU/Linux systems, like Debian or Ubuntu.\n"
-  mprint::color -fg ${GRAY} "Copyright (c) 2024 MDSANIMA DEV. All rights reserved. Licensed under the MIT license."
+  print::color -fg ${WHITE} -bg ${BLUE} -b -n " MDSANIMA DEV "
+  print::color -fg ${BLUE} " dotfiles ${CURRENT_GIT_TAG}\n"
+  print::color -fg ${WHITE} "This installer is only available for GNU/Linux systems, like Debian or Ubuntu.\n"
+  print::color -fg ${GRAY} "Copyright (c) 2024 MDSANIMA DEV. All rights reserved. Licensed under the MIT license."
 }
 
 dotfiles_installer

--- a/lib/README.md
+++ b/lib/README.md
@@ -3,13 +3,16 @@
 Below is documentation for the libraries included in this project, which you can utilize in your own projects.
 
 > [!NOTE]
-> Currently, the libraries are only available within this project and cannot be installed as a package using `sudo apt install` command. However, there are plans to make it available as a standalone package in the future.
+> Currently, the libraries are only available within this project and cannot be installed as a package using `apt install`.
+>
+> However, there are plans to make it available as a standalone package in the future.
 
 <details>
 <summary><strong>Table of Contents</strong> (click to expand)</summary>
 
 - [Libraries](#libraries)
   - [mdsanima-shell](#mdsanima-shell)
+    - [Available libraries](#available-libraries)
     - [Available functions](#available-functions)
     - [Example usages](#example-usages)
 
@@ -17,29 +20,30 @@ Below is documentation for the libraries included in this project, which you can
 
 ## mdsanima-shell
 
-This library contains functions thats help to execute _Shell Scripts_ on **GNU/Linux** systems, like _Debian_ or _Ubuntu_.
+This package contains libraries for functions that help execute _Shell Scripts_ on **GNU/Linux**, such as _Debian_ or _Ubuntu_.
+
+### Available libraries
+
+- [`libcolor`](./mdsanima-shell/libcolor.sh): Color palette definition that will be used throughout a project for consistent styling.
+- [`libconvert`](./mdsanima-shell/libconvert.sh): Converting data or values from one format or type to another.
+- [`libevent`](./mdsanima-shell/libevent.sh): Logging events or actions within a program for debugging or monitoring purposes.
+- [`libprint`](./mdsanima-shell/libprint.sh): Printing formatted text or data to the shell console or another output stream.
+- [`libutil`](./mdsanima-shell/libutil.sh): Utility that perform common tasks or operations needed across different parts of a project.
+
+Each file above contains appropriate documentation for each available function and how to use it.
 
 ### Available functions
 
-List of available files and functions:
-
-- `libcolor.sh`: Color schemes.
-- `libconvert.sh`: Functions for converting.
-  - `conver::hex_to_rgb`
-- `libevent.sh`: Functions for event logs.
-  - `event::debug`
-  - `event::dev`
-  - `event::error`
-  - `event::info`
-  - `event::success`
-  - `event::warning`
-- `libmprint.sh`: Functions for printing.
-  - `mprint::color`
-- `libutil.sh`: Functions for utility.
-  - `util::check_package_installed`
-  - `util::one_line_progress`
-
-Each file above contains appropriate documentation for each available function and how to use it.
+- `convert::hex_to_rgb`
+- `event::debug`
+- `event::dev`
+- `event::error`
+- `event::info`
+- `event::success`
+- `event::warning`
+- `print::color`
+- `util::check_package_installed`
+- `util::one_line_progress`
 
 ### Example usages
 
@@ -56,43 +60,37 @@ Example script file `test.sh` must be located on the root of this repository:
 ```shell
 #!/bin/bash
 
-# Importing libraries
+# Import library
 source "$PWD/lib/mdsanima-shell/libcolor.sh"
+source "$PWD/lib/mdsanima-shell/libconvert.sh"
 source "$PWD/lib/mdsanima-shell/libevent.sh"
-source "$PWD/lib/mdsanima-shell/libmprint.sh"
+source "$PWD/lib/mdsanima-shell/libprint.sh"
 source "$PWD/lib/mdsanima-shell/libutil.sh"
 
-# Testing mprint functions
-mprint::color -fg ${BLACK} -bg ${RED} "Black text on red background"
-mprint::color -fg 16 -bg 208 -bold "Bold black text on orange background"
-mprint::color -fg ${BLACK} -bg ${BLUE} -bold -nonewline " MDSANIMA "
-mprint::color -fg 27 " Blue text next to other"
-mprint::color "Normal text"
-mprint::color -fg 196 "Red text"
-mprint::color -fg 196 -b "Bold red text"
-mprint::color -fg 196 -i "Italic red text"
-mprint::color -fg ${BLUE} -b -italic "Bold italic blue text"
-mprint::color -n "This line is printed in "
-mprint::color -fg ${RED} -n "red "
-mprint::color -fg ${GREEN} -n "green "
-mprint::color -fg ${BLUE} -n "blue "
-mprint::color "colored text"
+# Test color library
+echo "RED color number: ${RED}"
 
-# Testing event functions
-event::dev
-event::info
-event::debug
-event::error
+# Test contert library
+hex="ff0000"
+rgb=$(convert::hex_to_rgb $hex)
+echo "HEX ${hex} color is converted to RGB: ${rgb}"
+
+# Test event library
 event::warning
 done=$(event::success)
 echo -e "${clean_line_seq}${done} Testing event functions was finished!"
 
-# Tesging util functions
+# Test print library
+print::color -fg 16 -bg 196 -bold "Bold black text on red background"
+print::color -fg ${BLACK} -bg ${BLUE} -bold -nonewline " MDSANIMA "
+print::color -fg 27 " Blue text next to other"
+
+# Test util library
 util::one_line_progress sudo apt update
 if util::check_package_installed git; then
-  echo "Package 'git' is installed!"
+  echo "Package git is installed!"
 else
-  echo "Package 'git' is not installed!"
+  echo "Package git is not installed!"
 fi
 ```
 

--- a/lib/mdsanima-shell/libcolor.sh
+++ b/lib/mdsanima-shell/libcolor.sh
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
-# This library is designed to define color names with color code number.
+# Library for color palette definition.
 
 
 # Generic

--- a/lib/mdsanima-shell/libconvert.sh
+++ b/lib/mdsanima-shell/libconvert.sh
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
-# This library is for converting functions.
+# Library for converting functions.
 
 
 #-------------------------------------------------------------------------------
@@ -19,11 +19,11 @@ function convert::hex_to_rgb() {
   local hex_color="$1"
   local awk_cmd='{print strtonum("0x" $0)}'
 
-  # Converting
+  # Convert HEX to RGB
   local r=$(echo "${hex_color:1:2}" | awk "${awk_cmd}")
   local g=$(echo "${hex_color:3:2}" | awk "${awk_cmd}")
   local b=$(echo "${hex_color:5:2}" | awk "${awk_cmd}")
 
   # Return RGB
-  echo "$r;$g;$b"
+  echo "${r};${g};${b}"
 }

--- a/lib/mdsanima-shell/libevent.sh
+++ b/lib/mdsanima-shell/libevent.sh
@@ -1,31 +1,29 @@
 # Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
-# This library is designed to print event names in colors. Events are displayed
-# with bold black text representing the event name and a selected color
-# background for emphasis.
+# Library for event logging functions.
 
 
 function event::debug() {
-  mprint::color -fg ${BLACK} -bg ${GRAY} -b " DEBUG "
+  print::color -fg ${BLACK} -bg ${GRAY} -b " DEBUG "
 }
 
 function event::dev() {
-  mprint::color -fg ${BLACK} -bg ${BLUE} -b " DEV "
+  print::color -fg ${BLACK} -bg ${BLUE} -b " DEV "
 }
 
 function event::error() {
-  mprint::color -fg ${BLACK} -bg ${RED} -b " ERROR "
+  print::color -fg ${BLACK} -bg ${RED} -b " ERROR "
 }
 
 function event::info() {
-  mprint::color -fg ${BLACK} -bg ${CYAN} -b " INFO "
+  print::color -fg ${BLACK} -bg ${CYAN} -b " INFO "
 }
 
 function event::success() {
-  mprint::color -fg ${BLACK} -bg ${LIME} -b " SUCCESS "
+  print::color -fg ${BLACK} -bg ${LIME} -b " SUCCESS "
 }
 
 function event::warning() {
-  mprint::color -fg ${BLACK} -bg ${ORANGE} -b " WARNING "
+  print::color -fg ${BLACK} -bg ${ORANGE} -b " WARNING "
 }

--- a/lib/mdsanima-shell/libprint.sh
+++ b/lib/mdsanima-shell/libprint.sh
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
-# This library is designed to print text in colors and other styles.
+# Library for printing functions.
 
 
 #-------------------------------------------------------------------------------
@@ -17,12 +17,12 @@
 #   <text>          The text to be printed in colors, required
 #
 # Usage:
-#   mprint::color -fg <color> -bg <color> -bold -italic -nonewline <text>
-#   mprint::color -fg 15 -bg 208 -bold "Bold white text on orange background"
-#   mprint::color -fg 196 -b -italic "Bold italic red text"
-#   mprint::color -fg ${BLACK} -bg ${ORANGE} "Black text on orange background"
+#   print::color -fg <color> -bg <color> -bold -italic -nonewline <text>
+#   print::color -fg 15 -bg 208 -b "Bold white text on orange background"
+#   print::color -fg 196 -b -italic "Bold italic red text"
+#   print::color -fg ${BLACK} -bg ${RED} "Black text on red background"
 #-------------------------------------------------------------------------------
-function mprint::color() {
+function print::color() {
   local fg_color
   local bg_color
   local bold_text

--- a/lib/mdsanima-shell/libutil.sh
+++ b/lib/mdsanima-shell/libutil.sh
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
-# This library is for utility functions.
+# Library for utility functions.
 
 
 # Cleaned line sequence


### PR DESCRIPTION
Refactored the shell script installation file and the library documentation to use the updated `libprint.sh` instead of the deprecated `libmprint.sh`.

Streamlined the usage of printing functions and improved the organization of the library README to enhance readability and increase the ease of finding information.

Conversions now explicitly denote the color format transformation from HEX to RGB. Removed redundant comments and updated color library descriptions for clarity.

Refactored code to adhere to more common naming conventions and improve project maintainability. Unified the format across event logging functions for consistency. Simplified the README presentation of library information by distinguishing libraries from functions. Clarified the library descriptions for a better understanding of their purposes.