### PR TITLE
feat: Expand color definitions on hexadecimal values

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -3,8 +3,7 @@
 Below is documentation for the libraries included in this project, which you can utilize in your own projects.
 
 > [!NOTE]
-> Currently, the libraries are only available within this project and cannot be installed as a package using `apt install`.
->
+> Currently, the libraries are only available within this project and cannot be installed as a package using `apt install` command.
 > However, there are plans to make it available as a standalone package in the future.
 
 <details>
@@ -24,26 +23,26 @@ This package contains libraries for functions that help execute _Shell Scripts_ 
 
 ### Available libraries
 
-- [`libcolor`](./mdsanima-shell/libcolor.sh): Color palette definition that will be used throughout a project for consistent styling.
-- [`libconvert`](./mdsanima-shell/libconvert.sh): Converting data or values from one format or type to another.
-- [`libevent`](./mdsanima-shell/libevent.sh): Logging events or actions within a program for debugging or monitoring purposes.
-- [`libprint`](./mdsanima-shell/libprint.sh): Printing formatted text or data to the shell console or another output stream.
-- [`libutil`](./mdsanima-shell/libutil.sh): Utility that perform common tasks or operations needed across different parts of a project.
+- [`libcolor.sh`](./mdsanima-shell/libcolor.sh): Color palette definition that will be used throughout a project for consistent styling.
+- [`libconvert.sh`](./mdsanima-shell/libconvert.sh): Converting data or values from one format or type to another.
+- [`libevent.sh`](./mdsanima-shell/libevent.sh): Logging events or actions within a program for debugging or monitoring purposes.
+- [`libprint.sh`](./mdsanima-shell/libprint.sh): Printing formatted text or data to the shell console or another output stream.
+- [`libutil.sh`](./mdsanima-shell/libutil.sh): Utility that perform common tasks or operations needed across different parts of a project.
 
 Each file above contains appropriate documentation for each available function and how to use it.
 
 ### Available functions
 
-- `convert::hex_to_rgb`
-- `event::debug`
-- `event::dev`
-- `event::error`
-- `event::info`
-- `event::success`
-- `event::warning`
-- `print::color`
-- `util::check_package_installed`
-- `util::one_line_progress`
+- [`convert::hex_to_rgb`](./mdsanima-shell/libconert.sh#L18)
+- [`event::debug`](./mdsanima-shell/libevent.sh#L7)
+- [`event::dev`](./mdsanima-shell/libevent.sh#L11)
+- [`event::error`](./mdsanima-shell/libevent.sh#L15)
+- [`event::info`](./mdsanima-shell/libevent.sh#L19)
+- [`event::success`](./mdsanima-shell/libevent.sh#L23)
+- [`event::warning`](./mdsanima-shell/libevent.sh#L27)
+- [`print::color`](./mdsanima-shell/libprint.sh#L25)
+- [`util::check_package_installed`](./mdsanima-shell/libutil.sh#L25)
+- [`util::one_line_progress`](./mdsanima-shell/libutil.sh#L50)
 
 ### Example usages
 
@@ -68,7 +67,9 @@ source "$PWD/lib/mdsanima-shell/libprint.sh"
 source "$PWD/lib/mdsanima-shell/libutil.sh"
 
 # Test color library
-echo "RED color number: ${RED}"
+echo "${RED}: int color: 'RED'"
+echo "${INT_RED}: int color: 'INT_RED'"
+echo "${HEX_RED}: hex color: 'HEX_RED'"
 
 # Test contert library
 hex="ff0000"
@@ -82,7 +83,7 @@ echo -e "${clean_line_seq}${done} Testing event functions was finished!"
 
 # Test print library
 print::color -fg 16 -bg 196 -bold "Bold black text on red background"
-print::color -fg ${BLACK} -bg ${BLUE} -bold -nonewline " MDSANIMA "
+print::color -fg ${BLACK} -bg ${INT_BLUE} -bold -nonewline " MDSANIMA "
 print::color -fg 27 " Blue text next to other"
 
 # Test util library

--- a/lib/mdsanima-shell/libcolor.sh
+++ b/lib/mdsanima-shell/libcolor.sh
@@ -4,40 +4,118 @@
 # Library for color palette definition.
 
 
-# Generic
-WHITE=15
-BLACK=16
+#-------------------------------------------------------------------------------
+# GLOBAL MAIN DEFAULT COLOR NAMES
+#-------------------------------------------------------------------------------
+readonly WHITE=15
+readonly BLACK=16
+readonly LIGHT=252
+readonly DARK=236
+readonly NIGHT=67
+readonly STORM=204
+readonly SHINE=107
+readonly TOKYO=73
+readonly TOWN=14
+readonly CYAN=45
+readonly SKY=39
+readonly BLUE=33
+readonly INDIGO=105
+readonly VIOLET=99
+readonly PURPLE=170
+readonly FUCHSIA=177
+readonly PINK=206
+readonly ROSE=203
+readonly RED=196
+readonly ORANGE=208
+readonly AMBER=215
+readonly YELLOW=220
+readonly LIME=148
+readonly GREEN=118
+readonly EMERALD=122
+readonly TEAL=43
+readonly GRAPHE=24
+readonly GITTER=30
+readonly SLATE=250
+readonly GRAY=245
+readonly ZINC=238
+readonly NEUTRAL=240
+readonly BASIC=242
+readonly STONE=244
 
-# Default
-LIGHT=252
-DARK=236
-NIGHT=67
-STORM=204
-SHINE=107
-TOKYO=73
-TOWN=14
-CYAN=45
-SKY=39
-BLUE=33
-INDIGO=105
-VIOLET=99
-PURPLE=170
-FUCHSIA=177
-PINK=206
-ROSE=203
-RED=196
-ORANGE=208
-AMBER=215
-YELLOW=220
-LIME=148
-GREEN=118
-EMERALD=122
-TEAL=43
-GRAPHE=24
-GITTER=30
-SLATE=250
-GRAY=245
-ZINC=238
-NEUTRAL=240
-BASIC=242
-STONE=244
+
+#-------------------------------------------------------------------------------
+# GLOBAL BASE INTEGER COLOR NAMES
+#-------------------------------------------------------------------------------
+readonly INT_WHITE=${WHITE}
+readonly INT_BLACK=${BLACK}
+readonly INT_LIGHT=${LIGHT}
+readonly INT_DARK=${DARK}
+readonly INT_NIGHT=${NIGHT}
+readonly INT_STORM=${STORM}
+readonly INT_SHINE=${SHINE}
+readonly INT_TOKYO=${TOKYO}
+readonly INT_TOWN=${TOWN}
+readonly INT_CYAN=${CYAN}
+readonly INT_SKY=${SKY}
+readonly INT_BLUE=${BLUE}
+readonly INT_INDIGO=${INDIGO}
+readonly INT_VIOLET=${VIOLET}
+readonly INT_PURPLE=${PURPLE}
+readonly INT_FUCHSIA=${FUCHSIA}
+readonly INT_PINK=${PINK}
+readonly INT_ROSE=${ROSE}
+readonly INT_RED=${RED}
+readonly INT_ORANGE=${ORANGE}
+readonly INT_AMBER=${AMBER}
+readonly INT_YELLOW=${YELLOW}
+readonly INT_LIME=${LIME}
+readonly INT_GREEN=${GREEN}
+readonly INT_EMERALD=${EMERALD}
+readonly INT_TEAL=${TEAL}
+readonly INT_GRAPHE=${GRAPHE}
+readonly INT_GITTER=${GITTER}
+readonly INT_SLATE=${SLATE}
+readonly INT_GRAY=${GRAY}
+readonly INT_ZINC=${ZINC}
+readonly INT_NEUTRAL=${NEUTRAL}
+readonly INT_BASIC=${BASIC}
+readonly INT_STONE=${STONE}
+
+
+#-------------------------------------------------------------------------------
+# GLOBAL BASE HEXADECIMAL COLOR NAMES
+#-------------------------------------------------------------------------------
+readonly HEX_WHITE="#ffffff"
+readonly HEX_BLACK="#000000"
+readonly HEX_LIGHT="#cad1d9"
+readonly HEX_DARK="#171b22"
+readonly HEX_NIGHT="#2b3558"
+readonly HEX_STORM="#f45270"
+readonly HEX_SHINE="#84a85c"
+readonly HEX_TOKYO="#277a75"
+readonly HEX_TOWN="#549daa"
+readonly HEX_CYAN="#06b6d4"
+readonly HEX_SKY="#0ea5e9"
+readonly HEX_BLUE="#3b82f6"
+readonly HEX_INDIGO="#6366f1"
+readonly HEX_VIOLET="#8b5cf6"
+readonly HEX_PURPLE="#a855f7"
+readonly HEX_FUCHSIA="#d946ef"
+readonly HEX_PINK="#ec4899"
+readonly HEX_ROSE="#f43f5e"
+readonly HEX_RED="#ef4444"
+readonly HEX_ORANGE="#f97316"
+readonly HEX_AMBER="#f59e0b"
+readonly HEX_YELLOW="#eab308"
+readonly HEX_LIME="#84cc16"
+readonly HEX_GREEN="#22c55e"
+readonly HEX_EMERALD="#10b981"
+readonly HEX_TEAL="#14b8a6"
+readonly HEX_GRAPHE="#2e83b4"
+readonly HEX_GITTER="#476bb2"
+readonly HEX_SLATE="#64748b"
+readonly HEX_GRAY="#6b7280"
+readonly HEX_ZINC="#71717a"
+readonly HEX_NEUTRAL="#737373"
+readonly HEX_BASIC="#777777"
+readonly HEX_STONE="#78716c"


### PR DESCRIPTION
In the color library, expanded color definitions with both integer and hexadecimal values for broader utility in scripting. Made color variable names read-only to enforce immutable color standards across the project. This change could facilitate future implementation of color-coded output or theming standards within scripts or command-line tools. Additionally, it lays the groundwork for consistency in color usage, preventing accidental overwrites and reducing errors.

Updated the README to include the '.sh' file extension in library references, enhancing clarity. Documented direct links to function definitions providing immediate access to code details. Improved example usages to showcase additional color values for better testing.

These enhancements are designed to improve developer experience by providing better documentation, clearer examples, and more robust tools for color management within the shell scripts.