### PR TITLE
feat: Add `clang-format` and `clang-tidy` configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 max_line_length = 120
 quote_type = double
 
-[*.{commitlintrc,eslint*,js,jsx,json,md,mjs,ts,tsx,versionrc}]
+[*.{commitlintrc,eslint*,js,jsx,json,md,mjs,ts,tsx,versionrc,todo}]
 indent_size = 2
 
 [*.{html,yml,yaml}]
@@ -32,6 +32,13 @@ max_line_length = 80
 [{*.svg,.env*}]
 insert_final_newline = false
 max_line_length = off
+
+[{.clang-format,.clang-tidy}]
+indent_size = 2
+
+[{CMakeLists.txt,*.{cmake,c,h,cc,hh,cpp,hpp,cxx,hxx}}]
+indent_size = 2
+max_line_length = 80
 
 [{Makefile,.gitattributes,.gitconfig,.gitcredentials,.gitmessage,.gitmodules}]
 indent_size = 8

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Defined base templates
 
+#-----------------------------------------------------------------------------------------------------------------------
 # .gitignore template: Python
+#-----------------------------------------------------------------------------------------------------------------------
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -162,8 +164,9 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-
+#-----------------------------------------------------------------------------------------------------------------------
 # .gitignore template: Node
+#-----------------------------------------------------------------------------------------------------------------------
 # Logs
 logs
 *.log
@@ -295,8 +298,85 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
+#-----------------------------------------------------------------------------------------------------------------------
+# .gitignore template: CMake
+#-----------------------------------------------------------------------------------------------------------------------
+# Files and directories
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+**/Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+build
 
+#-----------------------------------------------------------------------------------------------------------------------
+# .gitignore template: C and C++
+#-----------------------------------------------------------------------------------------------------------------------
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+*.slo
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lai
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.smod
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+#-----------------------------------------------------------------------------------------------------------------------
 # .gitignore template: MDSANIMA
+#-----------------------------------------------------------------------------------------------------------------------
 # Python setuptools_scm version
 _version.py
 

--- a/template/.clang-format
+++ b/template/.clang-format
@@ -1,0 +1,6 @@
+Language: Cpp
+
+BasedOnStyle: Google
+ColumnLimit: 80
+IndentWidth: 2
+SpacesBeforeTrailingComments: 2

--- a/template/.clang-tidy
+++ b/template/.clang-tidy
@@ -1,0 +1,27 @@
+Checks: "-*,
+  modernize-*,
+  readability-*,
+  performance-*,
+  bugprone-*"
+
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.FunctionCase
+    value: camelBack
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.GlobalVariableCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.MemberCase
+    value: camelBack
+  - key: readability-identifier-naming.StructCase
+    value: camelBack
+  - key: readability-identifier-naming.UnionCase
+    value: CamelCase
+  - key: readability-identifier-naming.VariableCase
+    value: camelBack
+
+WarningsAsErrors: "*"


### PR DESCRIPTION
Introduced new code style template configuration files for automated formatting tools like `.clang-format` and `.clang-tidy` configuration for consistent C/C++ code style enforcement.

Updated code styles and ignores for C/C++ and Python. Extended `.editorconfig` to support `.todo` files and C/C++ file formatting. Included C/C++ files in `.gitignore` with comprehensive rules for build artifacts and executables. Enriched Python and Node sections in `.gitignore` with clearer separators for readability.

The changes ensure better support and cleanliness in multi-language repositories, particularly those including C and C++ components, while maintaining the project's overall code quality and readability.