### PR TITLE
fix: Updated tmux config for better compatibility

### DIFF
--- a/config/tmux/mdsanima.conf
+++ b/config/tmux/mdsanima.conf
@@ -10,7 +10,6 @@
 
 # Uncomment the ssh options if you want to connect for the host.
 
-
 # Custom names for session, and first window
 rename-session mdsanima
 rename-window dev

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -4,18 +4,20 @@
 # This is a tmux base global configuration settings for my home lab hosts and
 # is simple as possible. Check out the other custom configuration files.
 
+# Unbind default prefix
+unbind C-b
 
 # Set a new prefix key
 set -g prefix `
 bind ` send-prefix
 
 # Set variables for the terminal
-set -g default-terminal "screen-256color"
-set-option -sa terminal-overrides ",st-256color:RGB"
+set -g default-terminal "tmux-256color"
+set-option -sa terminal-overrides ",xterm-256color:Tc"
 
-# More scroll in the buffer and messages duration to 4s
+# More scroll in the buffer and messages duration to 1s
 set -g history-limit 100000
-set -g display-time 4000
+set -g display-time 1000
 
 # Enable vim moiton and full mouse support
 set -g mode-keys vi
@@ -27,26 +29,8 @@ set -g pane-base-index 1
 set -g automatic-rename on
 set -g renumber-windows on
 
-# Status bar configuration
-set -g status-position top
-set -g status-interval 5
-set -g status-left-length 0
-set -g status-right-length 0
-
-# Custom host name and clock
-set -g status-right "#[fg=colour202]#H #[default]⌚ %H:%M:%S"
-
-# Custom color options
-set -g status-style fg=colour197
-set -g window-status-current-style fg=colour39
-set -g pane-border-style fg=colour240
-set -g pane-active-border-style fg=colour39
-
-# Unbind default prefix
-unbind C-b
-
 # ALT+R => Reload tmux.conf does not reset current config
-bind-key -n M-r source-file ~/.config/tmux/tmux.conf \; display-message "Config reloaded..."
+bind-key -n M-r source "$HOME/.config/tmux/tmux.conf" \; display-message "Config reloaded..."
 
 # ALT+J => New window
 bind-key -n M-j new-window
@@ -59,14 +43,30 @@ bind-key -n M-l select-window -t :+
 bind-key -n M-b split-window -v -c "#[pane_current_path]"
 bind-key -n M-v split-window -h -c "#[pane_current_path]"
 
-# ALT+Arrow keys => Switch panes
-bind-key -n M-Left select-pane -L
-bind-key -n M-Down select-pane -D
-bind-key -n M-Up select-pane -U
-bind-key -n M-Right select-pane -R
-
 # CTRL+Vim style => Switch panes
 bind-key -n C-h select-pane -L
 bind-key -n C-j select-pane -D
 bind-key -n C-k select-pane -U
 bind-key -n C-l select-pane -R
+
+# Status bar configuration
+set -g status-position top
+set -g status-interval 5
+set -g status-left-length 0
+set -g status-right-length 0
+
+# Custom clock
+set -g status-right "%H:%M:%S"
+
+# Custom colors
+set -g status-style "fg=colour16 bg=colour12"
+set -g window-status-current-style fg=colour50
+set -g pane-border-style fg=colour240
+set -g pane-active-border-style fg=colour39
+
+# List of plugins
+set -g @plugin "tmux-plugins/tpm"
+set -g @plugin "tmux-plugins/tmux-sensible"
+
+# Initialize TMUX plugin manager
+run "$HOME/.tmux/plugins/tpm/tpm"


### PR DESCRIPTION
Improved terminal compatibility by setting the default terminal to 'tmux-256color', alongside overrides for 'xterm-256color'. Unbound the default prefix C-b in favor of a backtick, enhancing personal workflow efficiency. Reduced message display time to 1s for faster feedback. Status bar appearance now has contrasting colors and the clock displays without the host name for a cleaner look.

Switched to Vim-like bindings for pane selection, removing the previous `Alt+Arrow` keys mappings for a more streamlined navigation experience.

Added tmux-plugins/tpm and tmux-sensible to the list of plugins, and ensured proper initialization for enhanced tmux utility.

These changes modernize the tmux experience, integrate plugin support, and tailor the UI for a more personalized and productive environment.