### PR TITLE
feat: Add hex color validation utility function

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -49,8 +49,9 @@ Each file above contains appropriate documentation for each available function a
 - [`util::is_string`](./mdsanima-shell/libutil.sh#L58)
 - [`util::is_special_char`](./mdsanima-shell/libutil.sh#L69)
 - [`util::is_first_char_special`](./mdsanima-shell/libutil.sh#L81)
-- [`util::contains_special_char`](./mdsanima-shell/libutil.sh#L93)
-- [`util::one_line_progress`](./mdsanima-shell/libutil.sh#L104)
+- [`util::is_hex`](./mdsanima-shell/libutil.sh#L93)
+- [`util::contains_special_char`](./mdsanima-shell/libutil.sh#L105)
+- [`util::one_line_progress`](./mdsanima-shell/libutil.sh#L116)
 
 ### Example usages
 

--- a/lib/mdsanima-shell/libutil.sh
+++ b/lib/mdsanima-shell/libutil.sh
@@ -90,6 +90,18 @@ function util::is_first_char_special() {
   fi
 }
 
+function util::is_hex() {
+  local hex="$1"
+  local first="${hex:0:1}"
+  if [[ "$first" == "#" ]] && [[ "${#hex}" -eq 7 ]] && [[ "${hex:1}" =~ ^[0-9a-fA-F]+$ ]]; then
+    # echo "SUCCESS $hex is a valid hex"
+    return 0
+  else
+    # echo "ERROR $hex is not a valid hex"
+    return 1
+  fi
+}
+
 function util::contains_special_char() {
   local argument="$1"
   if [[ "$argument" =~ [^[:alnum:]_] ]]; then


### PR DESCRIPTION
Introduced a new utility function to check for valid hex color strings. It verifies that the string starts with a '#' followed by exactly 6 hexadecimal digits.

This ensures that inputs conform to expected color code formats before processing or usage in the application.