### PR TITLE
feat: Add hex color mode in print function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Instructions for installing the dotfiles configuration. First, clone this reposi
 
 ### Linux
 
-Run the `./install.sh` script in the _Shell_ terminal to install the configuration on **GNU/Linux** systems like _Ubuntu_ or _Debian_. This script include the [ohmyzsh](https://github.com/ohmyzsh/ohmyzsh/) installation and many more.
+Run the `./install.sh` script in the _Shell_ terminal to install the configuration on **GNU/Linux** systems like _Debian_ or _Ubuntu_. This script include the [ohmyzsh](https://github.com/ohmyzsh/ohmyzsh/) installation and many more.
 
 ### Windows
 

--- a/install.sh
+++ b/install.sh
@@ -3,12 +3,12 @@
 # Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 # Licensed under the MIT license.
 
-# Installation script for dotfiles for GNU/Linux systems, like Debian or Ubuntu.
-
+# Installation script for dotfiles for GNU/Linux systems like Debian or Ubuntu.
 
 # Import necessary libraries
 source "$PWD/lib/mdsanima-shell/libcolor.sh"
 source "$PWD/lib/mdsanima-shell/libprint.sh"
+source "$PWD/lib/mdsanima-shell/libutil.sh"
 
 # List of packages to install
 APT_PACKAGES="python3-pip zsh powerline fonts-powerline zsh-theme-powerlevel9k"
@@ -20,7 +20,7 @@ CURRENT_GIT_TAG=$(git describe --tags)
 function dotfiles_installer() {
   print::color -fg ${WHITE} -bg ${BLUE} -b -n " MDSANIMA DEV "
   print::color -fg ${BLUE} " dotfiles ${CURRENT_GIT_TAG}\n"
-  print::color -fg ${WHITE} "This installer is only available for GNU/Linux systems, like Debian or Ubuntu.\n"
+  print::color -fg ${WHITE} "This installer is only available for GNU/Linux systems like Debian or Ubuntu.\n"
   print::color -fg ${GRAY} "Copyright (c) 2024 MDSANIMA DEV. All rights reserved. Licensed under the MIT license."
 }
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -81,7 +81,7 @@ echo "${INT_RED}: int color: 'INT_RED'"
 echo "${HEX_RED}: hex color: 'HEX_RED'"
 
 # Test contert library
-hex="ff0000"
+hex="#ff0000"
 rgb=$(convert::hex_to_rgb $hex)
 echo "HEX ${hex} color is converted to RGB: ${rgb}"
 

--- a/lib/mdsanima-shell/libutil.sh
+++ b/lib/mdsanima-shell/libutil.sh
@@ -91,13 +91,12 @@ function util::is_first_char_special() {
 }
 
 function util::is_hex() {
-  local hex="$1"
-  local first="${hex:0:1}"
-  if [[ "$first" == "#" ]] && [[ "${#hex}" -eq 7 ]] && [[ "${hex:1}" =~ ^[0-9a-fA-F]+$ ]]; then
-    # echo "SUCCESS $hex is a valid hex"
+  local argument="$1"
+  if [[ "$argument" =~ ^#[0-9a-fA-F]{6}$ ]]; then
+    # echo "SUCCESS $argument is a valid hex"
     return 0
   else
-    # echo "ERROR $hex is not a valid hex"
+    # echo "ERROR $argument is not a valid hex"
     return 1
   fi
 }


### PR DESCRIPTION
Refine color definition and output in printing functions to support both number-based and HEX color modes, introducing HEX validation and error handling in `libutil.sh`.

Synchronized terminology across documentation and script descriptions, ensuring consistency when referring to system compatibility.

Additionally, improved user guidance by correcting a HEX color prefix in `lib/README.md`.