### PR TITLE
chore: Add new SSH alias and refined Neovim configs

### DIFF
--- a/config/aliasrc
+++ b/config/aliasrc
@@ -1,3 +1,5 @@
+# Aliases definition
+
 alias rpi0="ssh mdsanima@192.168.1.27"
 alias rpi1="ssh mdsanima@192.168.1.32"
 alias rpi2="ssh mdsanima@192.168.1.34"
@@ -6,6 +8,7 @@ alias rpi4="ssh mdsanima@192.168.1.33"
 alias rpi5="ssh mdsanima@192.168.1.37"
 alias rpi6="ssh mdsanima@192.168.1.35"
 alias rpi7="ssh mdsanima@192.168.1.36"
+alias rpi8="ssh mdsanima@192.168.1.111"
 alias jet1="ssh mdsanima@192.168.1.24"
 alias jet2="ssh mdsanima@192.168.1.30"
 alias macb="ssh mdsanima@192.168.1.44"

--- a/config/nvim/autoload/mdsanima.vim
+++ b/config/nvim/autoload/mdsanima.vim
@@ -4,7 +4,6 @@
 " Autoloaded functions. Autoloading allows functions to be loaded on
 " demand, which makes startuptime faster and enforces function namespacing.
 
-
 " Testing
 function mdsanima#hello()
   echo 'Hello World'

--- a/config/nvim/colors/mdsanima.vim
+++ b/config/nvim/colors/mdsanima.vim
@@ -4,7 +4,6 @@
 " Custom `mdsanima` color theme. Based on the default `pablo` vim color file.
 " Run this command `vim -c 'edit $VIMRUNTIME/colors/pablo.vim'` for help.
 
-
 " Setup
 hi clear
 set notermguicolors

--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -3,6 +3,5 @@
 
 " Initial configuration for Neovim. Other configs will be loaded automatically.
 
-
 " Load color theme
 colorscheme mdsanima

--- a/config/nvim/plugin/autocmds.vim
+++ b/config/nvim/plugin/autocmds.vim
@@ -3,6 +3,5 @@
 
 " General autocommands.
 
-
 " Back to default terminal cursor style
 autocmd VimLeave * set guicursor=a:ver1-blinkon1

--- a/config/nvim/plugin/commands.vim
+++ b/config/nvim/plugin/commands.vim
@@ -1,4 +1,4 @@
 " Copyright (c) 2024 MDSANIMA DEV. All rights reserved.
 " Licensed under the MIT license.
 
-" General commands.
+" General commands. These commands are loaded on demand.

--- a/config/nvim/plugin/mappings.vim
+++ b/config/nvim/plugin/mappings.vim
@@ -3,7 +3,6 @@
 
 " Key mappings.
 
-
 " General
 map <C-S> :w<CR>            " CTRL+S to Save file
 map <C-Q> :q<CR>            " CTRL+Q to Quit file

--- a/config/nvim/plugin/mdsanima.vim
+++ b/config/nvim/plugin/mdsanima.vim
@@ -3,7 +3,6 @@
 
 " Custom `mdsanima` configuration setting options.
 
-
 " Setting
 set autoindent              " Indent from last line
 set autoread                " Read file on change


### PR DESCRIPTION
Introduced a new SSH alias for a newly configured device.

Cleaned up excess whitespace across various Neovim configuration files for a more organized and readable format.

Provided additional context to the description in `commands.vim` to improve clarity on command loading behavior.