### PR TITLE
ci: Update Dependabot package ecosystem workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,29 @@ updates:
     schedule:
       interval: daily
       timezone: Europe/Warsaw
-      time: "10:00"
-    labels: [deps, ci, workflow]
+      time: "12:00"
+    labels: [dependencies, workflow]
 
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: daily
-      timezone: Europe/Warsaw
-      time: "11:00"
-    labels: [deps, python, pip]
+  # - package-ecosystem: docker
+  #   directory: /
+  #   schedule:
+  #     interval: daily
+  #     timezone: Europe/Warsaw
+  #     time: "12:00"
+  #   labels: [dependencies, docker]
+
+  # - package-ecosystem: pip
+  #   directory: /
+  #   schedule:
+  #     interval: daily
+  #     timezone: Europe/Warsaw
+  #     time: "12:00"
+  #   labels: [dependencies, pip]
+
+  # - package-ecosystem: npm
+  #   directory: /
+  #   schedule:
+  #     interval: daily
+  #     timezone: Europe/Warsaw
+  #     time: "12:00"
+  #   labels: [dependencies, npm]


### PR DESCRIPTION
Adjusted the Dependabot update time to 12:00 for better alignment across different dependencies. Unified labels to `dependencies` and `workflow` to standardize terminology.

This is a template for use in other repository. Only active updates is package ecosystem for `github-actions` for this repository. Commented out `docker`, `pip`, and `npm` update schedules for maintenance or future activation.

These adjustments streamline the scheduling process and improve label clarity, facilitating easier management and readability.