### PR TITLE
chore: Update lint rules to allow inline HTML elements

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -18,7 +18,8 @@ MD026:
 MD027: true
 
 # Inline HTML
-MD033: false
+MD033:
+  allowed_elements: [center, details, div, h1, h2, strong, sub, summary]
 
 # Emphasis heading
 MD036:

--- a/config/aliasrc
+++ b/config/aliasrc
@@ -18,5 +18,4 @@ alias macb="ssh mdsanima@192.168.1.44"
 alias k="kubectl"
 
 # Editor
-alias vi="nvim"
 alias vim="nvim"


### PR DESCRIPTION
Enhanced `.markdownlint.yml` to allow specific inline HTML elements, improving flexibility in _Markdown_ syntax usage.

Updated `aliasrc` file to streamline the Neovim alias by removing the **vi** alias, ensuring consistency in editor command references.