### PR TITLE
fix: Terminal cursor style blinking-block on tmux

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -23,6 +23,9 @@ set -g display-time 1000
 set -g mode-keys vi
 set -g mouse on
 
+# Terminal cursor style, you can set `bar`, `block`, `blinking-bar` or `blinking-block` style
+set -g cursor-style blinking-block
+
 # Windows and panes index start at 1, not 0
 set -g base-index 1
 set -g pane-base-index 1
@@ -55,18 +58,11 @@ set -g status-interval 5
 set -g status-left-length 0
 set -g status-right-length 0
 
-# Custom clock
-set -g status-right "%H:%M:%S"
+# Custom status
+set -g status-right "#H   #(hostname -I | awk '{print $1}')    %A %H:%M:%S"
 
 # Custom colors
 set -g status-style "fg=colour16 bg=colour12"
 set -g window-status-current-style fg=colour50
 set -g pane-border-style fg=colour240
 set -g pane-active-border-style fg=colour39
-
-# List of plugins
-set -g @plugin "tmux-plugins/tpm"
-set -g @plugin "tmux-plugins/tmux-sensible"
-
-# Initialize TMUX plugin manager
-run "$HOME/.tmux/plugins/tpm/tpm"


### PR DESCRIPTION
Also update custom `status-right` with hostname icon, and ip address. The time on this status also add the curent day name.