### PR TITLE
chore: Update editor to skip plugins in core config for git

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -18,7 +18,7 @@
 	gpgsign = true
 	verbose = true
 [core]
-	editor = nvim
+	editor = nvim --clean
 	symlinks = true
 [include]
 	path = ~/.gitcredentials


### PR DESCRIPTION
Now the editor in `.gitconfig` updated to `nvim --clean` thats is skipping user configuration and plugins for git commit messages.